### PR TITLE
Allow the patches pipeline to run async

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,21 @@ Migrate database
 bundle exec rake db:migrate
 ```
 
+If you would like to run the patches asynchronously, or would like them to notify your hipchat room when they fail or succeed, you need to set up an initializer to set those options.
+
+```Ruby
+Patches::Config.configure do |config|
+  config.use_sidekiq = true
+
+  config.use_hipchat = true
+  config.hipchat_options = {
+    api_token: HIPCHATAPITOKEN,
+    room: HIPCHATROOMNAME,
+    user: HIPCHATUSER #maximum of 15 characters
+  }
+end
+```
+
 ## Creating Patches
 
 Generate a patch
@@ -55,4 +70,4 @@ require 'patches/capistrano'
 
 ## Multitenant
 
-Patches will detect if `Apartment` gem is installed and if there are any tenants and run the patches for each tenant 
+Patches will detect if `Apartment` gem is installed and if there are any tenants and run the patches for each tenant

--- a/lib/patches.rb
+++ b/lib/patches.rb
@@ -24,3 +24,7 @@ require "patches/engine" if defined?(Rails)
 require "patches/patch"
 require "patches/pending"
 require "patches/runner"
+require "patches/tenant_runner"
+require "patches/config"
+require "patches/notifier"
+require "patches/worker" if defined?(Sidekiq)

--- a/lib/patches/config.rb
+++ b/lib/patches/config.rb
@@ -1,0 +1,19 @@
+module Patches
+  class Config
+    class << self
+      class_attribute :use_sidekiq, :sidekiq_queue, :sidekiq_options, :use_hipchat, :hipchat_options
+
+      def sidekiq_queue
+        @sidekiq_queue ||= 'default'
+      end
+
+      def sidekiq_options
+        @sidekiq_options ||= { retry: false, queue: Patches::Config.sidekiq_queue }
+      end
+
+      def configure
+        yield self
+      end
+    end
+  end
+end

--- a/lib/patches/notifier.rb
+++ b/lib/patches/notifier.rb
@@ -1,0 +1,34 @@
+class Patches::Notifier
+  class << self
+    def notify_success(patches)
+      send_hipchat_message(success_message(patches), color: 'green')
+    end
+
+    def notify_failure(patch_path, error)
+      send_hipchat_message(failure_message(patch_path, error), color: 'red')
+    end
+
+    def success_message(patches)
+      message = "#{patches.count} patches succeeded"
+      append_tenant_message(message)
+    end
+
+    def failure_message(patch_path, error)
+      message = "Error applying patch: #{Pathname.new(patch_path).basename} failed with error: #{error}"
+      append_tenant_message(message)
+    end
+
+    def append_tenant_message(message)
+      message = message + " for tenant: #{Apartment::Tenant.current}" if defined?(Apartment)
+      message
+    end
+
+    private
+
+    def send_hipchat_message(message, options)
+      if defined?(HipChat) && Patches::Config.use_hipchat
+        HipChat::Client.new(Patches::Config.hipchat_options[:api_token])[Patches::Config.hipchat_options[:room]].send(Patches::Config.hipchat_options[:user], message, options)
+      end
+    end
+  end
+end

--- a/lib/patches/pending.rb
+++ b/lib/patches/pending.rb
@@ -9,9 +9,10 @@ class Patches::Pending
 
   def each
     return nil unless files
-    Patches.logger.info("Patches found: #{files.join(',')}")
+    new_files = files.reject { |file| already_run?(file) }
+    Patches.logger.info("Patches found: #{new_files.join(',')}")
 
-    files.each do |file|
+    new_files.each do |file|
       unless already_run?(file)
         yield file
       end

--- a/lib/patches/version.rb
+++ b/lib/patches/version.rb
@@ -1,3 +1,3 @@
 module Patches
-  VERSION = "0.1.8"
+  VERSION = "1.0.0"
 end

--- a/lib/patches/worker.rb
+++ b/lib/patches/worker.rb
@@ -1,0 +1,11 @@
+require 'sidekiq'
+
+class Patches::Worker
+  include Sidekiq::Worker
+
+  sidekiq_options Patches::Config.sidekiq_options
+
+  def perform(runner)
+    runner.constantize.new.perform
+  end
+end

--- a/patches.gemspec
+++ b/patches.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "factory_girl", "~> 4.5.0"
   spec.add_development_dependency "timecop", "~> 0.7.0"
   spec.add_development_dependency "database_cleaner", "~> 1.3.0"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "sidekiq", "~> 3.4.1"
 end

--- a/spec/example/201512123012_failing_test_patch.rb
+++ b/spec/example/201512123012_failing_test_patch.rb
@@ -1,0 +1,5 @@
+class FailingTestPatch < Patches::Base
+  def run
+    raise
+  end
+end

--- a/spec/example/201512123012_successful_test_patch.rb
+++ b/spec/example/201512123012_successful_test_patch.rb
@@ -1,4 +1,4 @@
-class TestPatch < Patches::Base
+class SuccessfulTestPatch < Patches::Base
   def run
     logger.info("Completed TestPatch")
   end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,31 +1,51 @@
 require 'spec_helper'
 
 describe Patches::Runner do
-  let(:examples_path) { Pathname.new(File.absolute_path(File.join(File.dirname(__FILE__), 'example/'))) }
-  let(:patch_path) { File.join(examples_path, '201512123012_test_patch.rb') }
-  let(:base) { File.basename(patch_path) }
+  describe '#perform' do
+    let(:examples_path) { Pathname.new(File.absolute_path(File.join(File.dirname(__FILE__), 'example/'))) }
+    let(:base) { File.basename(patch_path) }
 
-  before do
-    allow(Patches).to receive(:default_path).and_return(examples_path)
-  end
-
-  context 'patches' do
-    specify { expect(subject.path).to eql(Patches.default_path) }
-    specify do
-      expect(subject).to receive(:pending).and_return([patch_path])
-      expect(subject).to receive(:complete!).with(base)
-      expect(subject.perform).to_not be_empty
+    before do
+      allow(Patches).to receive(:default_path).and_return(examples_path)
+      allow(Patches::Notifier).to receive(:notify_success).and_return(nil)
+      allow(Patches::Notifier).to receive(:notify_failure).and_return(nil)
     end
-  end
 
-  context 'invalid patch' do
-    specify do
-      expect(subject).to receive(:pending).and_return(['test.rb'])
-      expect {
-        subject.perform
-      }.to raise_error(Patches::Runner::UnknownPatch)
+    context 'with a failing patch' do
+      let(:patch_path) { File.join(examples_path, '201512123012_failing_test_patch.rb') }
+
+      specify do
+        expect(Patches::Notifier).to receive(:notify_failure)
+        expect {
+          Patches::Runner.new.perform
+        }.to raise_error
+      end
+    end
+
+    context 'with a successful patch' do
+      let(:patch_path) { File.join(examples_path, '201512123012_successful_test_patch.rb') }
+
+      context 'patches' do
+        specify { expect(subject.path).to eql(Patches.default_path) }
+        specify do
+          expect(subject).to receive(:pending).and_return([patch_path])
+          expect(subject).to receive(:complete!).with(base)
+          expect(Patches::Notifier).to receive(:notify_success)
+          expect(subject.perform).to_not be_empty
+        end
+      end
+    end
+
+    context 'with an invalid patch' do
+      let(:patch_path) { File.join(examples_path, '201512123012_successful_test_patch.rb') }
+
+      specify do
+        expect(subject).to receive(:pending).and_return(['test.rb'])
+        expect {
+          subject.perform
+        }.to raise_error(Patches::Runner::UnknownPatch)
+      end
     end
   end
 end
-
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require 'database_cleaner'
 require 'active_model'
 require 'active_record'
 require 'patches'
+require 'pry'
 
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3',
                                         database: 'test.db')


### PR DESCRIPTION
I've added the ability to run the Patches::TenantRunner and Patches::Runner classes from within a Sidekiq worker. I've also added the ability to set the patches to notify hipchat when they fail or succeed.

I've updated the docs/usage to show the configuration that is necessary to enable these features. Otherwise, this PR does not affect the public API at all.

The notifications look like this:

Success:
![image](https://cloud.githubusercontent.com/assets/3908721/8843985/321a2942-3153-11e5-8cc4-b29542fa0816.png)

Failure:
![image](https://cloud.githubusercontent.com/assets/3908721/8843905/2d1f323a-3152-11e5-8bbd-f1bad222ffd4.png)
