### PR TITLE
Improve hipchat options

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,8 @@ Patches::Config.configure do |config|
   config.hipchat_options = {
     api_token: ENV['HIPCHAT_TOKEN'],
     room: ENV['HIPCHAT_ROOM'],
-    user: ENV['HIPCHAT_USERNAME'] #maximum of 15 characters
+    user: ENV['HIPCHAT_USERNAME'], # maximum of 15 characters
+    api_version: 'v1', # optional
   }
 end
 ```

--- a/lib/patches/config.rb
+++ b/lib/patches/config.rb
@@ -1,18 +1,44 @@
 module Patches
   class Config
     class << self
-      class_attribute :use_sidekiq, :sidekiq_queue, :sidekiq_options, :use_hipchat, :hipchat_options
-
-      def sidekiq_queue
-        @sidekiq_queue ||= 'default'
+      def configuration
+        @configuration ||= Configuration.new
       end
 
-      def sidekiq_options
-        @sidekiq_options ||= { retry: false, queue: Patches::Config.sidekiq_queue }
+      def configuration=(config)
+        @configuration = config
       end
 
       def configure
-        yield self
+        yield configuration
+      end
+
+      class Configuration
+        attr_accessor :use_sidekiq, :sidekiq_queue, :sidekiq_options, :use_hipchat, :hipchat_options
+
+        def initialize
+          @sidekiq_queue = 'default'
+        end
+
+        def sidekiq_options
+          @sidekiq_options ||= { retry: false, queue: sidekiq_queue }
+        end
+
+        def hipchat_api_token
+          hipchat_options[:api_token]
+        end
+
+        def hipchat_init_options
+          hipchat_options.except(:api_token, :room, :user)
+        end
+
+        def hipchat_room
+          hipchat_options[:room]
+        end
+
+        def hipchat_user
+          hipchat_options[:user]
+        end
       end
     end
   end

--- a/lib/patches/notifier.rb
+++ b/lib/patches/notifier.rb
@@ -28,14 +28,18 @@ class Patches::Notifier
       message
     end
 
+    def send_hipchat_message(message, options)
+      return unless defined?(HipChat) && config.use_hipchat
+
+      client = HipChat::Client.new(config.hipchat_api_token, config.hipchat_init_options)
+      room = client[config.hipchat_room]
+      room.send(config.hipchat_user, message, options)
+    end
+
     private
 
-    def send_hipchat_message(message, options)
-      return unless defined?(HipChat) && Patches::Config.use_hipchat
-
-      client = HipChat::Client.new(Patches::Config.hipchat_options[:api_token])
-      room   = client[Patches::Config.hipchat_options[:room]]
-      room.send(Patches::Config.hipchat_options[:user], message, options)
+    def config
+      Patches::Config.configuration
     end
   end
 end

--- a/lib/patches/version.rb
+++ b/lib/patches/version.rb
@@ -1,3 +1,3 @@
 module Patches
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/lib/patches/worker.rb
+++ b/lib/patches/worker.rb
@@ -3,7 +3,7 @@ require 'sidekiq'
 class Patches::Worker
   include Sidekiq::Worker
 
-  sidekiq_options Patches::Config.sidekiq_options
+  sidekiq_options Patches::Config.configuration.sidekiq_options
 
   def perform(runner)
     runner.constantize.new.perform

--- a/lib/tasks/patches.rake
+++ b/lib/tasks/patches.rake
@@ -7,7 +7,7 @@ namespace :patches do
       runner = Patches::Runner
     end
 
-    if defined?(Sidekiq) && Patches::Config.use_sidekiq
+    if defined?(Sidekiq) && Patches::Config.configuration.use_sidekiq
       Patches::Worker.perform_async(runner)
     else
       runner.new.perform

--- a/patches.gemspec
+++ b/patches.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "sidekiq", "~> 3.4.1"
+  spec.add_development_dependency "hipchat"
+  spec.add_development_dependency "webmock"
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper'
+
+describe Patches::Config do
+  let(:patches_config) { described_class.configuration }
+
+  before do
+    described_class.configuration = nil
+    described_class.configure do |config|
+    end
+  end
+
+  describe '#use_sidekiq' do
+    subject { patches_config.use_sidekiq }
+    before { patches_config.use_sidekiq = true }
+
+    it 'is the configured value' do
+      expect(subject).to eq(true)
+    end
+  end
+
+  describe '#sidekiq_queue' do
+    subject { patches_config.sidekiq_queue }
+
+    context 'when not configured' do
+      it 'is the default queue' do
+        expect(subject).to eq('default')
+      end
+    end
+
+    context 'when configured' do
+      before { patches_config.sidekiq_queue = 'patches_queue' }
+
+      it 'is the configured value' do
+        expect(subject).to eq('patches_queue')
+      end
+    end
+  end
+
+  describe '#sidekiq_options' do
+    subject { patches_config.sidekiq_options }
+    before { patches_config.sidekiq_queue = 'default_queue' }
+
+    context 'when not configured' do
+      it 'is the default option' do
+        expect(subject).to eq({ retry: false, queue: 'default_queue' })
+      end
+    end
+
+    context 'when configured' do
+      before { patches_config.sidekiq_options = { retry: true, queue: 'custom_queue' } }
+
+      it 'is the configured value' do
+        expect(subject).to eq({ retry: true, queue: 'custom_queue' })
+      end
+    end
+  end
+
+  describe '#use_hipchat' do
+    subject { patches_config.use_hipchat }
+    before { patches_config.use_hipchat = true }
+
+    it 'is the configured value' do
+      expect(subject).to eq(true)
+    end
+  end
+
+  describe '#hipchat_api_token' do
+    subject { patches_config.hipchat_api_token }
+    before { patches_config.hipchat_options = { api_token: 'hipchat_api_token' } }
+
+    it 'is api_token option from hipchat_options' do
+      expect(subject).to eq('hipchat_api_token')
+    end
+  end
+
+  describe '#hipchat_init_options' do
+    subject { patches_config.hipchat_init_options }
+
+    context 'when extra options exist' do
+      before do
+        patches_config.hipchat_options = {
+          api_token: 'hipchat_api_token',
+          room: 'hipchat_room',
+          user: 'hipchat_user',
+          api_version: 'v1',
+        }
+      end
+
+      it 'is all options from hipchat_options except :api_token, :room and :user' do
+        expect(subject).to eq({ api_version: 'v1' })
+      end
+    end
+
+    context 'when no extra options exist' do
+      before do
+        patches_config.hipchat_options = {
+          api_token: 'hipchat_api_token',
+          room: 'hipchat_room',
+          user: 'hipchat_user',
+        }
+      end
+
+      it 'is an empty hash' do
+        expect(subject).to eq({ })
+      end
+    end
+  end
+
+  describe '#hipchat_room' do
+    subject { patches_config.hipchat_room }
+    before { patches_config.hipchat_options = { room: 'hipchat_room' } }
+
+    it 'is room option from hipchat_options' do
+      expect(subject).to eq('hipchat_room')
+    end
+  end
+
+  describe '#hipchat_user' do
+    subject { patches_config.hipchat_user }
+    before { patches_config.hipchat_options = { user: 'hipchat_user' } }
+
+    it 'is user option from hipchat_options' do
+      expect(subject).to eq('hipchat_user')
+    end
+  end
+end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+require 'hipchat'
+
+describe Patches::Notifier do
+  let(:notifier) { described_class }
+
+  describe '#send_hipchat_message' do
+    subject { notifier.send_hipchat_message(message, options) }
+
+    let(:message) { 'This is a message' }
+    let(:options) { { an_option: 'ABC' } }
+
+    before do
+      Patches::Config.configuration = nil
+      Patches::Config.configure do |config|
+        config.use_hipchat = use_hipchat
+        config.hipchat_options = {
+          api_token: 'HIPCHAT_API_TOKEN',
+          room: 'HIPCHAT_ROOM',
+          user: 'HIPCHAT_USER',
+          api_version: 'v1',
+        }
+      end
+    end
+
+    context 'where Hipchat is defined and use_hipchat config is true' do
+      let(:use_hipchat) { true }
+      let(:hipchat_client) { HipChat::Client.new('TOKEN') }
+      let(:hipchat_client_room) { double('Hipchat Client Room') }
+
+      it 'sends a message to hipchat room' do
+        expect(HipChat::Client).to receive(:new).with('HIPCHAT_API_TOKEN', { api_version: 'v1' }).and_return(hipchat_client)
+        expect(hipchat_client).to receive(:[]).with('HIPCHAT_ROOM').and_return(hipchat_client_room)
+        expect(hipchat_client_room).to receive(:send).
+          with('HIPCHAT_USER', 'This is a message', { an_option: 'ABC' })
+        subject
+      end
+    end
+
+    context 'where Hipchat is not defined' do
+      let(:use_hipchat) { true }
+
+      before do
+        hide_const('HipChat')
+      end
+
+      specify do
+        expect { subject }.to_not raise_error
+      end
+    end
+
+    context 'where use_hipchat config is not true' do
+      let(:use_hipchat) { false }
+
+      it 'does not send a message to hipchat room' do
+        expect(HipChat::Client).to_not receive(:new)
+        subject
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ require 'active_model'
 require 'active_record'
 require 'patches'
 require 'pry'
+require 'webmock/rspec'
 
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3',
                                         database: 'test.db')


### PR DESCRIPTION
The primary motivation is to allow apps to use either api_version 1 or 2 of the hipchat API. Since there are other options that can be passed into the initialization of a `HipChat::Client`, I've added `hipchat_init_options` to the patches configuration to allow for this.

So in an initializer in an app, I can now have:

```
Patches::Config.configure do |config|
  config.hipchat_options = {
    api_token: ENV['HIPCHAT_TOKEN'],
    room: 'My Room',
    user: 'PatchRunner',
    api_version: 'v1',
  }
end
```