### PR TITLE
NEP-10148 Add worker parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [3.2.0] - 2020-07-16
+### Added
+- Added `Patches::Worker` extra parameters to support forward compatibility with the upcoming releases
 
-## [3.0.1] - 2018-11-19
+## [3.1.0] - 2018-11-19
 ### Added
 - Set icon_emoji of posted slack message to :dog:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added `Patches::Worker` extra parameters to support forward compatibility with the upcoming releases
 
-## [3.1.0] - 2018-11-19
+## [3.1.0] - 2019-11-25
+### Fixed
+- Gem compatibility with Apartment 2
+
+## [3.0.1] - 2018-11-19
 ### Added
 - Set icon_emoji of posted slack message to :dog:
 

--- a/lib/patches/version.rb
+++ b/lib/patches/version.rb
@@ -1,6 +1,6 @@
 module Patches
   MAJOR = 3
-  MINOR = 1
+  MINOR = 2
   PATCH = 0
   VERSION = [MAJOR, MINOR, PATCH].compact.join(".").freeze
 end

--- a/lib/patches/worker.rb
+++ b/lib/patches/worker.rb
@@ -5,7 +5,7 @@ class Patches::Worker
 
   sidekiq_options Patches::Config.configuration.sidekiq_options
 
-  def perform(runner)
+  def perform(runner, params = {})
     runner.constantize.new.perform
   end
 end


### PR DESCRIPTION
This PR adds support for additional parameters that can be passed to `Patches::Worker.perform_async`. This will allow the gem to be forward and backward compatible with the changes to the `Patches::Worker` in the upcoming releases.