### PR TITLE
NEP-10148 Application version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [3.3.0] - 2020-07-17
+### Added
+- Application version constraints
+
 ## [3.2.0] - 2020-07-16
 ### Added
 - Added `Patches::Worker` extra parameters to support forward compatibility with the upcoming releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [3.3.0] - 2020-07-17
+
+## [3.3.0] - 2020-07-20
 ### Added
 - Application version constraints
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,8 +62,12 @@ To prevent this case, set the application version in the config:
 
 ```ruby
 Patches::Config.configure do |config|
-  config.application_version = File.read(Rails.root.join('REVISION'))
-  config.retry_after_version_mismatch_in = 1.minute
+  revision_file_path = Rails.root.join('REVISION')
+
+  if File.exist?(revision_file_path)
+    config.application_version = File.read(revision_file_path)
+    config.retry_after_version_mismatch_in = 1.minute
+  end
 end
 ```
 

--- a/lib/patches/config.rb
+++ b/lib/patches/config.rb
@@ -14,8 +14,15 @@ module Patches
       end
 
       class Configuration
-        attr_accessor :use_sidekiq, :sidekiq_queue, :sidekiq_options,
-          :sidekiq_parallel, :use_slack, :slack_options
+        attr_accessor \
+          :application_version,
+          :retry_after_version_mismatch_in,
+          :sidekiq_options,
+          :sidekiq_parallel,
+          :sidekiq_queue,
+          :slack_options,
+          :use_sidekiq,
+          :use_slack
 
         def initialize
           @sidekiq_queue = 'default'
@@ -23,6 +30,10 @@ module Patches
 
         def sidekiq_options
           @sidekiq_options ||= { retry: false, queue: sidekiq_queue }
+        end
+
+        def retry_after_version_mismatch_in
+          @retry_after_version_mismatch_in ||= 1.minute
         end
 
         def slack_channel

--- a/lib/patches/version.rb
+++ b/lib/patches/version.rb
@@ -1,6 +1,6 @@
 module Patches
   MAJOR = 3
-  MINOR = 2
+  MINOR = 3
   PATCH = 0
   VERSION = [MAJOR, MINOR, PATCH].compact.join(".").freeze
 end

--- a/lib/patches/worker.rb
+++ b/lib/patches/worker.rb
@@ -6,6 +6,18 @@ class Patches::Worker
   sidekiq_options Patches::Config.configuration.sidekiq_options
 
   def perform(runner, params = {})
-    runner.constantize.new.perform
+    if valid_application_version?(params)
+      runner.constantize.new.perform
+    else
+      self.class.perform_in(Patches::Config.configuration.retry_after_version_mismatch_in, runner, params)
+    end
+  end
+
+  private
+
+  def valid_application_version?(params)
+    return true unless params[:application_version]
+    return true unless Patches::Config.configuration.application_version
+    Patches::Config.configuration.application_version == params[:application_version]
   end
 end

--- a/lib/patches/worker.rb
+++ b/lib/patches/worker.rb
@@ -16,8 +16,8 @@ class Patches::Worker
   private
 
   def valid_application_version?(params)
-    return true unless params[:application_version]
+    return true unless params['application_version']
     return true unless Patches::Config.configuration.application_version
-    Patches::Config.configuration.application_version == params[:application_version]
+    Patches::Config.configuration.application_version == params['application_version']
   end
 end

--- a/lib/tasks/patches.rake
+++ b/lib/tasks/patches.rake
@@ -8,7 +8,10 @@ namespace :patches do
     end
 
     if defined?(Sidekiq) && Patches::Config.configuration.use_sidekiq
-      Patches::Worker.perform_async(runner)
+      Patches::Worker.perform_async(
+        runner,
+        application_version: Patches::Config.configuration.application_version
+      )
     else
       runner.new.perform
     end

--- a/patches.gemspec
+++ b/patches.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "sqlite3", "~> 1.3.5"
-  spec.add_development_dependency "rspec-rails", "~> 3.2.0"
+  spec.add_development_dependency "rspec-rails", "~> 4.0.0"
   spec.add_development_dependency "capybara", "~> 2.3.0"
   spec.add_development_dependency "generator_spec", "~> 0.9.0"
   spec.add_development_dependency "simplecov", "~> 0.10"

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require "patches/worker"
+
+describe Patches::Worker do
+  describe '#perform' do
+    let(:runner) { instance_double(Patches::Runner, perform: true) }
+
+    before do
+      allow(Patches::Config.configuration).to receive(:application_version) { application_version }
+      allow(Patches::Runner).to receive(:new) { runner }
+    end
+
+    context 'when application_version config is set' do
+      let(:application_version) { '5828321' }
+
+      context 'when application version matches' do
+        it 'runs patches' do
+          expect(runner).to receive(:perform)
+          subject.perform('Patches::Runner', application_version: application_version)
+        end
+      end
+
+      context 'when application_version does not match' do
+        it 'does not run patches' do
+          expect(runner).not_to receive(:perform)
+          subject.perform('Patches::Runner', application_version: 'd8f190c')
+        end
+
+        it 'reschedules the job' do
+          expect(Patches::Worker).to receive(:perform_in).with(1.minute, 'Patches::Runner', application_version: 'd8f190c')
+          subject.perform('Patches::Runner', application_version: 'd8f190c')
+        end
+      end
+    end
+
+    context 'when application config is not set' do
+      let(:application_version) { nil }
+
+      it 'runs patches' do
+        expect(runner).to receive(:perform)
+        subject.perform('Patches::Runner', application_version: 'd8f190c')
+      end
+    end
+  end
+end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -16,19 +16,19 @@ describe Patches::Worker do
       context 'when application version matches' do
         it 'runs patches' do
           expect(runner).to receive(:perform)
-          subject.perform('Patches::Runner', application_version: application_version)
+          subject.perform('Patches::Runner', 'application_version' => application_version)
         end
       end
 
       context 'when application_version does not match' do
         it 'does not run patches' do
           expect(runner).not_to receive(:perform)
-          subject.perform('Patches::Runner', application_version: 'd8f190c')
+          subject.perform('Patches::Runner', 'application_version' => 'd8f190c')
         end
 
         it 'reschedules the job' do
-          expect(Patches::Worker).to receive(:perform_in).with(1.minute, 'Patches::Runner', application_version: 'd8f190c')
-          subject.perform('Patches::Runner', application_version: 'd8f190c')
+          expect(Patches::Worker).to receive(:perform_in).with(1.minute, 'Patches::Runner', 'application_version' => 'd8f190c')
+          subject.perform('Patches::Runner', 'application_version' => 'd8f190c')
         end
       end
     end
@@ -38,7 +38,7 @@ describe Patches::Worker do
 
       it 'runs patches' do
         expect(runner).to receive(:perform)
-        subject.perform('Patches::Runner', application_version: 'd8f190c')
+        subject.perform('Patches::Runner', 'application_version' => 'd8f190c')
       end
     end
   end


### PR DESCRIPTION
In environments where a rolling update of sidekiq workers is performed during the deployment, multiple versions of the application run at the same time. If a Patches job is scheduled by the new application version during the rolling update, there is a possibility that it can be executed by the old application version, which will not have all the required patch files.

This PR introduces an application version check. If an old application picks up the job and application versions don't match, the job is rescheduled in Sidekiq.