### PR TITLE
NEP-10148 TenantWorker forward compatibility with application version constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.4.0] - 2020-07-21
+### Added
+- `Patches::TenantWorker` application version constraint forward compatibility
+
 ## [3.3.0] - 2020-07-20
 ### Added
 - Application version constraints

--- a/lib/patches.rb
+++ b/lib/patches.rb
@@ -22,6 +22,7 @@ end
 require "patches/base"
 require "patches/config"
 require "patches/tenant_run_concern"
+require "patches/application_version_validation"
 require "patches/tenant_worker" if defined?(Sidekiq)
 require "patches/engine" if defined?(Rails)
 require "patches/patch"

--- a/lib/patches/application_version_validation.rb
+++ b/lib/patches/application_version_validation.rb
@@ -1,0 +1,9 @@
+module Patches
+  module ApplicationVersionValidation
+    def valid_application_version?(application_version)
+      return true unless application_version
+      return true unless Patches::Config.configuration.application_version
+      Patches::Config.configuration.application_version == application_version
+    end
+  end
+end

--- a/lib/patches/tenant_worker.rb
+++ b/lib/patches/tenant_worker.rb
@@ -3,10 +3,15 @@ require 'sidekiq'
 class Patches::TenantWorker
   include Sidekiq::Worker
   include Patches::TenantRunConcern
+  include Patches::ApplicationVersionValidation
 
   sidekiq_options Patches::Config.configuration.sidekiq_options
 
-  def perform(tenant_name, path)
-    run(tenant_name, path)
+  def perform(tenant_name, path, params = {})
+    if valid_application_version?(params['application_version'])
+      run(tenant_name, path)
+    else
+      self.class.perform_in(Patches::Config.configuration.retry_after_version_mismatch_in, tenant_name, path, params)
+    end
   end
 end

--- a/lib/patches/version.rb
+++ b/lib/patches/version.rb
@@ -1,6 +1,6 @@
 module Patches
   MAJOR = 3
-  MINOR = 3
+  MINOR = 4
   PATCH = 0
   VERSION = [MAJOR, MINOR, PATCH].compact.join(".").freeze
 end

--- a/lib/patches/worker.rb
+++ b/lib/patches/worker.rb
@@ -2,22 +2,15 @@ require 'sidekiq'
 
 class Patches::Worker
   include Sidekiq::Worker
+  include Patches::ApplicationVersionValidation
 
   sidekiq_options Patches::Config.configuration.sidekiq_options
 
   def perform(runner, params = {})
-    if valid_application_version?(params)
+    if valid_application_version?(params['application_version'])
       runner.constantize.new.perform
     else
       self.class.perform_in(Patches::Config.configuration.retry_after_version_mismatch_in, runner, params)
     end
-  end
-
-  private
-
-  def valid_application_version?(params)
-    return true unless params['application_version']
-    return true unless Patches::Config.configuration.application_version
-    Patches::Config.configuration.application_version == params['application_version']
   end
 end

--- a/spec/tenant_worker_spec.rb
+++ b/spec/tenant_worker_spec.rb
@@ -3,9 +3,42 @@ require "patches/tenant_worker"
 
 describe Patches::TenantWorker do
   describe '#perform' do
-    specify do
-      is_expected.to receive(:run).with('test', 'path')
-      subject.perform('test', 'path')
+    let(:runner) { instance_double(Patches::Runner, perform: true) }
+
+    before do
+      allow(Patches::Config.configuration).to receive(:application_version) { application_version }
+    end
+
+    context 'when application_version config is set' do
+      let(:application_version) { '5828321' }
+
+      context 'when application version matches' do
+        it 'runs patches' do
+          expect(subject).to receive(:run).with('test', 'path')
+          subject.perform('test', 'path', 'application_version' => application_version)
+        end
+      end
+
+      context 'when application_version does not match' do
+        it 'does not run patches' do
+          expect(subject).not_to receive(:run)
+          subject.perform('test', 'path', 'application_version' => 'd8f190c')
+        end
+
+        it 'reschedules the job' do
+          expect(Patches::TenantWorker).to receive(:perform_in).with(1.minute, 'test', 'path', 'application_version' => 'd8f190c')
+          subject.perform('test', 'path', 'application_version' => 'd8f190c')
+        end
+      end
+    end
+
+    context 'when application config is not set' do
+      let(:application_version) { nil }
+
+      it 'runs patches' do
+        expect(subject).to receive(:run).with('test', 'path')
+        subject.perform('test', 'path', 'application_version' => 'd8f190c')
+      end
     end
   end
 end


### PR DESCRIPTION
The `TenantWorker` Sidekiq worker class needs to adhere to the same application version constraints as the `Worker` class.