### PR TITLE
NEP-10148 Enable application version constraint support on TenantWorker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.4.0] - 2020-07-21
+## [3.5.0] - 2020-07-22
+### Added
+- Enable application version constraint support on `Patches::TenantWorker`
+
+## [3.4.0] - 2020-07-22
 ### Added
 - `Patches::TenantWorker` application version constraint forward compatibility
 

--- a/lib/patches/tenant_runner.rb
+++ b/lib/patches/tenant_runner.rb
@@ -11,7 +11,11 @@ class Patches::TenantRunner
     Patches.logger.info("Patches tenant runner for: #{tenants.join(',')}")
     tenants.each do |tenant|
       if parallel?
-        Patches::TenantWorker.perform_async(tenant, path)
+        Patches::TenantWorker.perform_async(
+          tenant,
+          path,
+          application_version: Patches::Config.configuration.application_version
+        )
       else
         run(tenant, path)
       end

--- a/lib/patches/version.rb
+++ b/lib/patches/version.rb
@@ -1,6 +1,6 @@
 module Patches
   MAJOR = 3
-  MINOR = 4
+  MINOR = 5
   PATCH = 0
   VERSION = [MAJOR, MINOR, PATCH].compact.join(".").freeze
 end

--- a/spec/tenant_runner_spec.rb
+++ b/spec/tenant_runner_spec.rb
@@ -11,10 +11,12 @@ require "patches/tenant_worker"
 
 describe Patches::TenantRunner do
   let(:runner) { double('Runner') }
+  let(:application_version) { 'd8f190c' }
 
   before do
     Sidekiq::Testing.fake!
     allow(Patches).to receive(:default_path).and_return('')
+    allow(Patches::Config.configuration).to receive(:application_version) { application_version }
   end
 
   context 'with tenants' do
@@ -39,7 +41,7 @@ describe Patches::TenantRunner do
 
       specify do
         expect(subject.tenants).to eql(['test'])
-        expect(Patches::TenantWorker).to receive(:perform_async).with('test', nil).and_call_original
+        expect(Patches::TenantWorker).to receive(:perform_async).with('test', nil, application_version: application_version).and_call_original
         expect { subject.perform }.to change(Patches::TenantWorker.jobs, :size).by(1)
       end
 
@@ -48,8 +50,8 @@ describe Patches::TenantRunner do
 
         specify do
           expect(subject.tenants).to eql(['test', 'test2'])
-          expect(Patches::TenantWorker).to receive(:perform_async).with('test', nil).and_call_original
-          expect(Patches::TenantWorker).to receive(:perform_async).with('test2', nil).and_call_original
+          expect(Patches::TenantWorker).to receive(:perform_async).with('test', nil, application_version: application_version).and_call_original
+          expect(Patches::TenantWorker).to receive(:perform_async).with('test2', nil, application_version: application_version).and_call_original
           expect { subject.perform }.to change(Patches::TenantWorker.jobs, :size).by(2)
         end
       end


### PR DESCRIPTION
Adds the `application_version` parameter to the `Patches::TenantWorker.perform_async` calls