### PR TITLE
Bump to version 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.6.2] - 2022-08-10
+
+Fixes incorrect release - tag and published gem back in sync
+
+## [3.6.1] - 2022-08-10
+### Added
+- Github actions to publish to Rubygems upon release
+
+### Fixed
+- Fix `patches:pending` rake task
+
 ## [3.6.0] - 2022-05-27
+
+3.6.1 changes were incorrectly published as 3.6.0 but tagged as 3.6.1
+
 ### Added
 - Added `notification_prefix` and `notification_suffix` to configuration options
 - Linked to docs/usage.md in README

--- a/lib/patches/version.rb
+++ b/lib/patches/version.rb
@@ -1,6 +1,6 @@
 module Patches
   MAJOR = 3
   MINOR = 6
-  PATCH = 0
+  PATCH = 2
   VERSION = [MAJOR, MINOR, PATCH].compact.join(".").freeze
 end


### PR DESCRIPTION
The gem version was not updated in the last release so version 3.6.1 changes were published in the 3.6.0 gem. Updated the version to 3.6.2 so that tag and gem version is back in sync.