### PR TITLE
Implement per-tenant error handling.

### DIFF
--- a/lib/patches/patches_error.rb
+++ b/lib/patches/patches_error.rb
@@ -1,0 +1,1 @@
+class PatchesError < StandardError; end

--- a/lib/patches/tenant_patch_unsuccessful_error.rb
+++ b/lib/patches/tenant_patch_unsuccessful_error.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TenantPatchUnsuccessfulError < PatchesError
-  attr_reader :tenant, :patch, :error
+  attr_reader :tenant, :patch, :exception
 
   def initialize(message = nil, tenant:, path:, exception:)
     message ||= "Error applying patch '#{path}' for tenant '#{tenant}': #{exception.message}"

--- a/lib/patches/tenant_patch_unsuccessful_error.rb
+++ b/lib/patches/tenant_patch_unsuccessful_error.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class TenantPatchUnsuccessfulError < PatchesError
+  attr_reader :tenant, :patch, :error
+
+  def initialize(message = nil, tenant:, path:, exception:)
+    message ||= "Error applying patch '#{path}' for tenant '#{tenant}': #{exception.message}"
+    super(message)
+
+    @tenant = tenant
+    @path = path
+    @exception = exception
+  end
+end

--- a/lib/patches/tenant_run_concern.rb
+++ b/lib/patches/tenant_run_concern.rb
@@ -4,6 +4,10 @@ module Patches
       Apartment::Tenant.switch(tenant_name) do
         Patches::Runner.new(path).perform
       end
+    rescue StandardError => e
+      Patches.logger.error(e.message)
+      Patches.logger.error(e.backtrace.join("\n"))
+      raise(TenantPatchUnsuccessfulError, tenant: tenant_name, path: path, exception: e)
     end
   end
 end

--- a/lib/patches/tenant_runner.rb
+++ b/lib/patches/tenant_runner.rb
@@ -9,6 +9,7 @@ class Patches::TenantRunner
 
   def perform
     Patches.logger.info("Patches tenant runner for: #{tenants.join(',')}")
+    failures = []
     tenants.each do |tenant|
       if parallel?
         Patches::TenantWorker.perform_async(
@@ -17,9 +18,14 @@ class Patches::TenantRunner
           application_version: Patches::Config.configuration.application_version
         )
       else
-        run(tenant, path)
+        begin
+          run(tenant, path)
+        rescue TenantPatchUnsuccessfulError => e
+          failures << e
+        end
       end
     end
+    raise_failures(failures) if failures.any?
   end
 
   def tenants
@@ -30,5 +36,12 @@ class Patches::TenantRunner
 
   def parallel?
     Patches::Config.configuration.sidekiq_parallel
+  end
+
+  def raise_failures(failures)
+    message = 'Patching failed for one or more tenants: '
+    message += failures.map { |f| "#{f.tenant} (#{f.path}, #{f.exception.message})" }.join(', ')
+
+    raise(PatchesError, message)
   end
 end


### PR DESCRIPTION
This is a concept for how we could possibly handle patch failures for individual tenants while continuing to patch remaining tenants and reporting the failures at the end.